### PR TITLE
Adding margin-top to "Add File(s)" button

### DIFF
--- a/styles/attachmentGroup.scss
+++ b/styles/attachmentGroup.scss
@@ -117,6 +117,7 @@
             }
             .add-button {
                 border: 1px solid transparent;
+                margin-top: 5px;
                 &:focus {
                     background-color: aliceblue;
                 }


### PR DESCRIPTION
- Adding margin-top to "Add File(s)" button as the border of it was not aligning with the border of already present attachment item's border. Adding a top margin of 5 pixels fixes the mis-alignment

![image](https://user-images.githubusercontent.com/31500022/42320685-cfb57d60-8073-11e8-9b19-092c12c75cd4.png)
